### PR TITLE
Add None option to dietary restriction dropdown

### DIFF
--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -108,6 +108,7 @@
                         </Select>
                     </div>
                     <Select label="Dietary Restriction" name="dietary-restriction" value={application.dietaryRestriction}>
+                        <option value="">None</option>
                         <option>Vegetarian</option>
                         <option>Vegan</option>
                         <option>Celiac Disease</option>


### PR DESCRIPTION
Previously unable to deselect dietary restrictions on registration page. Now fixed with a "None" option