### PR TITLE
Judging admin page updates

### DIFF
--- a/src/lib/server/judging.ts
+++ b/src/lib/server/judging.ts
@@ -202,54 +202,100 @@ export const Judging = {
      * Get aggregated scores for all projects (Leaderboard), grouped by track.
      */
     getAllProjectScores: async () => {
+        const allCriteria = await prisma.judgingCriterion.findMany({
+            orderBy: { order: 'asc' }
+        });
+
+        const optionalCriteria = allCriteria.filter(c => c.optional);
+
         const projects = await prisma.project.findMany({
             include: {
                 judgements: {
                     include: {
-                        scores: true,
-                        user: { select: { curve: true } }
+                        scores: { include: { criterion: true } },
+                        user: { select: { name: true, curve: true } }
                     }
                 },
                 Track: true
             }
         });
 
-        // Calculate scores
         const calculated = projects.map(p => {
-            const totalScore = p.judgements.reduce((sum, j) => {
-                const curve = j.user.curve || 0;
-                return sum + j.scores.reduce((s, score) => s + score.score + curve, 0);
-            }, 0);
+            const judgementCount = p.judgements.length;
 
-            const count = p.judgements.length;
-            const average = count > 0 ? (totalScore / count).toFixed(2) : "0.00";
+            const coreTotal = p.judgements.reduce((sum, j) => {
+                const curve = j.user.curve || 0;
+                const judgeCore = j.scores
+                    .filter(s => !s.criterion.optional)
+                    .reduce((s, score) => s + score.score + curve, 0);
+                return sum + judgeCore;
+            }, 0);
+            const coreScore = judgementCount > 0 ? coreTotal / judgementCount : 0;
+
+            const optionalScores: Record<string, number | null> = {};
+            for (const criterion of optionalCriteria) {
+                const scoringJudgements = p.judgements.filter(j =>
+                    j.scores.some(s => s.criterionId === criterion.id)
+                );
+                if (scoringJudgements.length === 0) {
+                    optionalScores[criterion.id] = null;
+                } else {
+                    const total = scoringJudgements.reduce((sum, j) => {
+                        const curve = j.user.curve || 0;
+                        const s = j.scores.find(s => s.criterionId === criterion.id);
+                        return sum + (s ? s.score + curve : 0);
+                    }, 0);
+                    optionalScores[criterion.id] = total / scoringJudgements.length;
+                }
+            }
+
+            const judgeBreakdowns = p.judgements.map(j => {
+                const curve = j.user.curve || 0;
+                return {
+                    judgeName: j.user.name,
+                    scores: j.scores.map(s => ({
+                        criterionId: s.criterionId,
+                        criterionName: s.criterion.name,
+                        isOptional: s.criterion.optional,
+                        curvedScore: s.score + curve
+                    }))
+                };
+            });
 
             return {
                 id: p.id,
                 name: p.name,
                 track: p.Track?.name || p.track,
                 tableNumber: p.tableNumber,
-                judgementCount: count,
-                totalScore,
-                averageScore: average
+                judgementCount,
+                coreScore,
+                optionalScores,
+                judgeBreakdowns
             };
         });
 
         // Group by track
         const grouped: Record<string, typeof calculated> = {};
-
         for (const p of calculated) {
             const track = p.track || "General";
             if (!grouped[track]) grouped[track] = [];
             grouped[track].push(p);
         }
 
-        // Sort each track
+        // Default sort: core score descending
         for (const track in grouped) {
-            grouped[track].sort((a, b) => Number(b.averageScore) - Number(a.averageScore));
+            grouped[track].sort((a, b) => b.coreScore - a.coreScore);
         }
 
-        return grouped;
+        return {
+            results: grouped,
+            optionalCriteria: optionalCriteria.map(c => ({
+                id: c.id,
+                slug: c.slug,
+                name: c.name,
+                maxScore: c.maxScore
+            }))
+        };
     },
 
     /**

--- a/src/routes/admin/judges/+page.svelte
+++ b/src/routes/admin/judges/+page.svelte
@@ -13,7 +13,7 @@
     let selectedJudge = $state<any>(null);
     let selectedTables = $state<number[]>([]);
     let isSubmitting = $state(false);
-    let assignForm: HTMLFormElement;
+    let assignForm = $state<HTMLFormElement | undefined>();
 
     // Add Judge State
     let showAddJudgeModal = $state(false);
@@ -98,7 +98,7 @@
     // Remove Judge State
     let showRemoveJudgeModal = $state(false);
     let judgeToRemove = $state<any>(null);
-    let removeJudgeForm: HTMLFormElement;
+    let removeJudgeForm = $state<HTMLFormElement | undefined>();
 
     function handleRemoveConfirm() {
         if (removeJudgeForm) removeJudgeForm.requestSubmit();

--- a/src/routes/admin/scores/+page.server.ts
+++ b/src/routes/admin/scores/+page.server.ts
@@ -3,8 +3,8 @@ import { fail } from '@sveltejs/kit';
 import { Judging } from '$lib/server/judging';
 
 export const load: PageServerLoad = async () => {
-    const results = await Judging.getAllProjectScores();
-    return { results };
+    const { results, optionalCriteria } = await Judging.getAllProjectScores();
+    return { results, optionalCriteria };
 };
 
 export const actions: Actions = {

--- a/src/routes/admin/scores/+page.svelte
+++ b/src/routes/admin/scores/+page.svelte
@@ -7,17 +7,11 @@
     import Modal from "$components/Modal.svelte";
 
     let { data } = $props();
+
     let isClearing = $state(false);
     let isEmailing = $state(false);
-    
     let showEmailModal = $state(false);
     let emailForm: HTMLFormElement;
-
-    // We can rely on correct form behavior with the modal
-    const handleEmailConfirm = () => {
-        if (emailForm) emailForm.requestSubmit();
-        showEmailModal = false;
-    };
 
     let showSingleEmailModal = $state(false);
     let selectedTeamId = $state<string>("");
@@ -25,11 +19,48 @@
     let isSendingSingleEmail = $state(false);
     let singleEmailForm: HTMLFormElement;
 
+    let toggledOptional = $state<string[]>([]);
+    // sortBy: 'display' uses the current display score; a criterion id sorts by that optional column
+    let sortBy = $state('display');
+    let expandAll = $state(false);
+
+    function toggleOptional(criterionId: string) {
+        if (toggledOptional.includes(criterionId)) {
+            toggledOptional = toggledOptional.filter(id => id !== criterionId);
+        } else {
+            toggledOptional = [...toggledOptional, criterionId];
+        }
+        if (sortBy !== 'display') sortBy = 'display';
+    }
+
+    function getDisplayScore(result: { coreScore: number; optionalScores: Record<string, number | null> }): number {
+        let score = result.coreScore;
+        for (const id of toggledOptional) {
+            score += result.optionalScores[id] ?? 0;
+        }
+        return score;
+    }
+
+    function getSortedResults(results: (typeof data.results)[string]) {
+        return [...results].sort((a, b) => {
+            if (sortBy === 'display') {
+                return getDisplayScore(b) - getDisplayScore(a);
+            }
+            const aScore = a.optionalScores[sortBy] ?? -Infinity;
+            const bScore = b.optionalScores[sortBy] ?? -Infinity;
+            return bScore - aScore;
+        });
+    }
+
+    const handleEmailConfirm = () => {
+        if (emailForm) emailForm.requestSubmit();
+        showEmailModal = false;
+    };
+
     const handleSingleEmailConfirm = () => {
         if (singleEmailForm) singleEmailForm.requestSubmit();
         showSingleEmailModal = false;
     };
-
 
     const confirmClear = () => {
         return confirm("Are you sure? This will delete ALL judgements and assignments. This cannot be undone.");
@@ -80,7 +111,7 @@
             <h1 class="text-2xl font-bold font-serif text-secondary">Results & Scores</h1>
             <p class="text-secondary/70">Live ranking of teams based on average judge scores.</p>
         </div>
-        
+
         <div class="flex gap-2">
             <!-- Email Form (Hidden) -->
             <form method="POST" action="?/emailResults" bind:this={emailForm} use:enhance={() => {
@@ -92,7 +123,15 @@
                 };
             }} class="hidden"></form>
 
-            <button 
+            <button
+                onclick={() => expandAll = !expandAll}
+                class="flex items-center gap-2 px-4 py-2 bg-secondary/10 text-secondary rounded-lg hover:bg-secondary/20 transition-colors font-bold text-sm"
+            >
+                <Icon icon={expandAll ? "mdi:chevron-up" : "mdi:chevron-down"} />
+                {expandAll ? "Collapse All" : "Expand All"}
+            </button>
+
+            <button
                 onclick={() => showEmailModal = true}
                 disabled={isEmailing}
                 class="flex items-center gap-2 px-4 py-2 bg-blue-100 text-blue-600 rounded-lg hover:bg-blue-200 transition-colors font-bold text-sm disabled:opacity-50"
@@ -102,7 +141,7 @@
             </button>
 
             <form method="POST" action="?/clearAll" use:enhance={() => {
-                if(!confirmClear()) return ({ update }) => update({ reset: false }); // Cancel
+                if(!confirmClear()) return ({ update }) => update({ reset: false });
                 isClearing = true;
                 return async ({ update }) => {
                     isClearing = false;
@@ -117,9 +156,44 @@
         </div>
     </div>
 
-    <!-- Leaderboard Table -->
+    <!-- Optional criteria toggles -->
+    {#if data.optionalCriteria.length > 0}
+        <div class="flex flex-wrap items-center gap-2 mb-6">
+            <span class="text-xs font-bold text-secondary/50 uppercase tracking-widest">Include in score:</span>
+            {#each data.optionalCriteria as criterion}
+                {@const isToggled = toggledOptional.includes(criterion.id)}
+                {@const isSorting = sortBy === criterion.id}
+                <div class="flex items-center rounded-lg overflow-hidden border border-secondary/15 text-sm font-bold">
+                    <button
+                        onclick={() => toggleOptional(criterion.id)}
+                        class="px-3 py-1.5 transition-colors {isToggled ? 'bg-accent text-white' : 'bg-white/60 text-secondary/60 hover:bg-secondary/10'}"
+                    >
+                        {isToggled ? '✓' : '+'} {criterion.name}
+                    </button>
+                    <button
+                        onclick={() => sortBy = isSorting ? 'display' : criterion.id}
+                        class="px-2 py-1.5 border-l border-secondary/15 transition-colors {isSorting ? 'bg-accent/20 text-accent' : 'bg-white/40 text-secondary/40 hover:bg-secondary/10'}"
+                        title="Sort by {criterion.name}"
+                    >
+                        <Icon icon={isSorting ? "mdi:sort-descending" : "mdi:sort"} class="w-3.5 h-3.5" />
+                    </button>
+                </div>
+            {/each}
+            {#if sortBy !== 'display'}
+                <button
+                    onclick={() => sortBy = 'display'}
+                    class="text-xs px-2 py-1 text-secondary/50 hover:text-secondary transition-colors"
+                >
+                    Reset sort
+                </button>
+            {/if}
+        </div>
+    {/if}
+
+    <!-- Leaderboard -->
     <div class="space-y-12">
         {#each Object.entries(data.results) as [track, results]}
+            {@const sorted = getSortedResults(results)}
             <div class="space-y-4">
                 <div class="flex items-center gap-4">
                     <h2 class="text-xl font-bold font-serif text-secondary">{track}</h2>
@@ -133,12 +207,21 @@
                                 <th class="p-4 font-bold w-16 text-center">Rank</th>
                                 <th class="p-4 font-bold">Team</th>
                                 <th class="p-4 font-bold text-center w-24">Judges</th>
-                                <th class="p-4 font-bold text-right w-32">Avg Score</th>
+                                {#each data.optionalCriteria as criterion}
+                                    {#if toggledOptional.includes(criterion.id) || sortBy === criterion.id}
+                                        <th class="p-4 font-bold text-right w-32 text-accent/70">
+                                            {criterion.name}
+                                        </th>
+                                    {/if}
+                                {/each}
+                                <th class="p-4 font-bold text-right w-32">
+                                    {toggledOptional.length > 0 ? 'Score' : 'Final Score'}
+                                </th>
                                 <th class="p-4 font-bold text-right w-24">Actions</th>
                             </tr>
                         </thead>
                         <tbody class="divide-y divide-secondary/5">
-                            {#each results as result, i}
+                            {#each sorted as result, i}
                                 <tr class="hover:bg-white/50 transition-colors">
                                     <td class="p-4 font-mono text-secondary/50 text-center">#{i + 1}</td>
                                     <td class="p-4 font-bold text-secondary">
@@ -152,11 +235,20 @@
                                             {result.judgementCount}
                                         </span>
                                     </td>
+                                    {#each data.optionalCriteria as criterion}
+                                        {#if toggledOptional.includes(criterion.id) || sortBy === criterion.id}
+                                            <td class="p-4 text-right font-mono text-sm text-accent/70">
+                                                {result.optionalScores[criterion.id] != null
+                                                    ? result.optionalScores[criterion.id]!.toFixed(2)
+                                                    : '—'}
+                                            </td>
+                                        {/if}
+                                    {/each}
                                     <td class="p-4 text-right font-mono font-bold text-lg text-accent">
-                                        {result.averageScore}
+                                        {getDisplayScore(result).toFixed(2)}
                                     </td>
                                     <td class="p-4 text-right">
-                                        <button 
+                                        <button
                                             onclick={() => {
                                                 selectedTeamId = result.id;
                                                 selectedTeamName = result.name;
@@ -165,14 +257,35 @@
                                             class="text-xs px-2 py-1 bg-blue-50 text-blue-600 rounded hover:bg-blue-100 transition-colors"
                                             title="Send feedback email to this team"
                                         >
-                                            Email Feedback
+                                            Email
                                         </button>
                                     </td>
                                 </tr>
+                                {#if expandAll && result.judgeBreakdowns.length > 0}
+                                    <tr class="bg-secondary/[0.02]">
+                                        <td colspan="99" class="px-8 pb-4 pt-2">
+                                            <div class="flex flex-wrap gap-4">
+                                                {#each result.judgeBreakdowns as breakdown}
+                                                    <div class="bg-white/80 rounded-lg border border-secondary/10 p-3 text-xs min-w-40">
+                                                        <p class="font-bold text-secondary mb-2">{breakdown.judgeName}</p>
+                                                        {#each breakdown.scores as score}
+                                                            <div class="flex justify-between gap-4 text-secondary/70">
+                                                                <span class="{score.isOptional ? 'italic text-accent/60' : ''}">
+                                                                    {score.criterionName}{score.isOptional ? ' *' : ''}
+                                                                </span>
+                                                                <span class="font-mono font-bold text-secondary">{score.curvedScore.toFixed(1)}</span>
+                                                            </div>
+                                                        {/each}
+                                                    </div>
+                                                {/each}
+                                            </div>
+                                        </td>
+                                    </tr>
+                                {/if}
                             {/each}
                             {#if results.length === 0}
                                 <tr>
-                                    <td colspan="4" class="p-8 text-center text-secondary/40 italic">
+                                    <td colspan="99" class="p-8 text-center text-secondary/40 italic">
                                         No scores recorded yet.
                                     </td>
                                 </tr>

--- a/src/routes/staff/teams/+page.svelte
+++ b/src/routes/staff/teams/+page.svelte
@@ -19,9 +19,9 @@
    let selectedProjectForEdit = $state<any>(null);
    let isSubmitting = $state(false);
    
-   let createForm: HTMLFormElement;
-   let editForm: HTMLFormElement;
-   let assignForm: HTMLFormElement;
+   let createForm = $state<HTMLFormElement | undefined>();
+   let editForm = $state<HTMLFormElement | undefined>();
+   let assignForm = $state<HTMLFormElement | undefined>();
 
    let searchTerm = $state("");
    // Filter unassigned


### PR DESCRIPTION
Handling optional judging criteria and enhancing the leaderboard display. The changes include backend updates to the score aggregation logic, as well as frontend enhancements that allow admins to toggle and sort by optional criteria, view detailed judge breakdowns, and improve form handling.

The backend now calculates core and optional scores separately, provides per-judge breakdowns, and returns metadata about optional criteria for use in the UI. The leaderboard is now sorted by core score by default, with support for including optional criteria in the displayed score.